### PR TITLE
webpack.prod.js: fix a new Node syntax issue

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,7 +1,7 @@
 import webpack from 'webpack';
 import { merge } from 'webpack-merge';
 import common from './webpack.common.js';
-import packageJson from './package.json' assert { type: "json" };
+import packageJson from './package.json' with { type: "json" };
 
 export default merge(common, {
   mode: 'production',


### PR DESCRIPTION
Without this fix, I am getting with Node 22:

```
SyntaxError: Unexpected identifier 'assert'
```

The issue is explained in this answer:
https://stackoverflow.com/a/78876692/598057

```
... Thus, swapping from assert to with will fix your program for Node 22 and later at the expense of breaking it for Node 16 and 17.
```