### PR TITLE
test/end2end: findBetterPageStart: do not assert on the page number

### DIFF
--- a/test/end2end/9000_strictdoc/findBetterPageStart/test_case.py
+++ b/test/end2end/9000_strictdoc/findBetterPageStart/test_case.py
@@ -34,7 +34,9 @@ class Test(BaseCase):
 
     def test_01(self):
         self.helper.do_open(case1_html_file_url)
-        self.helper.assert_document_has_pages(3)
+        # 2 or 3 pages are produced on Firefox or Chrome, so don't assert on
+        # the page number.
+        # self.helper.assert_document_has_pages(3)
 
         # 1. Check that the specific admonition title has the no-hanging flag
         target = self.find_element(

--- a/test/end2end/helpers/helper.py
+++ b/test/end2end/helpers/helper.py
@@ -94,8 +94,8 @@ class Helper:
         if report:
             print('-> paper:', paper)
             print('-> pages:', pages)
-        assert paper == count
-        assert pages == count
+        assert paper == count, f"{paper} == {count}, pages: {pages}"
+        assert pages == count, f"{pages} == {count}, paper: {paper}"
 
     # Element
 


### PR DESCRIPTION
Because it can be different between Firefox/Chrome which is not important for what this test is testing.