### PR TITLE
Enable console.assert logging in config

### DIFF
--- a/examples/test/current.html
+++ b/examples/test/current.html
@@ -8,9 +8,11 @@
   <meta name="description" content="HTML2PDF end2end test" />
   <title>Test page</title>
   <link rel="stylesheet" href="css/main.css">
+      <!-- data-console-assert="true" -->
   <script
     defer
     data-debug-mode="true"
+    data-console-assert="true"
     data-print-height='100mm'
     data-print-font-size='12pt'
     data-page-break-after-selectors='.after'

--- a/src/DOM.js
+++ b/src/DOM.js
@@ -9,6 +9,7 @@ export default class DocumentObjectModel {
     // * private
     this._debugMode = config.debugMode;
     this._debug = config.debugMode ? { ...config.debugConfig.DOM } : {};
+    this._assert = config.consoleAssert ? true : false;
   }
 
   // CREATE ELEMENTS
@@ -170,7 +171,7 @@ export default class DocumentObjectModel {
     }
 
     if (first === '[') {
-      this._debug._ && console.assert(
+      this._assert && console.assert(
         selector.at(-1) === ']', `the ${selector} selector is not OK.`
       );
       const attr = selector.substring(1, selector.length - 1);
@@ -199,7 +200,7 @@ export default class DocumentObjectModel {
       element.id = id;
       return
     } else if (first === '[') {
-      this._debug._ && console.assert(
+      this._assert && console.assert(
         selector.at(-1) === ']', `the ${selector} selector is not OK.`
       );
       const attr = selector.substring(1, selector.length - 1);
@@ -229,7 +230,7 @@ export default class DocumentObjectModel {
     }
 
     const first = selector.charAt(0);
-    console.assert(first.match(/[a-zA-Z#\[\.]/), `removeAttribute() expects a valid selector, but received ${selector}`)
+    this._assert && console.assert(first.match(/[a-zA-Z#\[\.]/), `removeAttribute() expects a valid selector, but received ${selector}`)
 
     if (first === '.') {
       const cl = selector.substring(1);
@@ -240,7 +241,7 @@ export default class DocumentObjectModel {
       element.removeAttribute(id);
       return
     } else if (first === '[') {
-      this._debug._ && console.assert(
+      this._assert && console.assert(
         selector.at(-1) === ']', `the ${selector} selector is not OK.`
       );
       const attr = selector.substring(1, selector.length - 1);

--- a/src/app.js
+++ b/src/app.js
@@ -65,6 +65,7 @@ export default class App {
     this.debugMode && console.info('⚙️ Current config with debugConfig:', this.config);
     this.debugMode && console.timeEnd("⏱️ Config time");
 
+    this.config.consoleAssert && console.info('🧧 Assertions enabled.');
 
     // * prepare helpers
 

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,10 @@ import SELECTOR from './selector.js';
 
 export default function createConfig(params) {
 
+  // * Normalize string booleans in config object
+  // * (e.g. "true" → true)
+  params = convertStringBools(params);
+
   // ? used in style.js
   let config = {
     // * Debug mode is set in the user configuration.
@@ -151,4 +155,38 @@ export default function createConfig(params) {
   config.debugMode && console.info('Config with converted units:', config);
 
   return config;
+}
+
+/**
+ * Returns a copy of the object where string values
+ * that clearly represent boolean values ("true", "false", "1", "0", "")
+ * are converted to true or false.
+ *
+ * Conversion rules:
+ *   - "true", "1" (case-insensitive) → true
+ *   - "false", "0", "" (case-insensitive) → false
+ *   - all other values (including numbers and other strings) are left unchanged
+ *   - the original object is not modified
+ *
+ * @param {Object} obj — the input object
+ * @returns {Object} — a new object with normalized boolean values
+ */
+function convertStringBools(obj) {
+  const result = { ...obj };
+
+  for (const key in result) {
+    const value = result[key];
+
+    if (typeof value === "string") {
+      const lowered = value.toLowerCase();
+
+      if (lowered === "true" || lowered === "1") {
+        result[key] = true;
+      } else if (lowered === "false" || lowered === "0" || lowered === "") {
+        result[key] = false;
+      }
+    }
+  }
+
+  return result;
 }

--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,11 @@ export default function createConfig(params) {
     debugMode: false,
     // ** The preloader is only debugged when enabled via user configuration.
 
+    // * Assert messages are enabled in the user settings by the parameter
+    // * data-console-assert="true".
+    // * By default is disabled.
+    consoleAssert: false,
+
     // Register option to print for informational purposes:
     preloader: false,
     preloaderTarget: '',

--- a/src/layout.js
+++ b/src/layout.js
@@ -25,6 +25,7 @@ export default class Layout {
 
     this._config = config;
     this._debug = config.debugMode ? { ...config.debugConfig.layout } : {};
+    this._assert = config.consoleAssert ? true : false;
     this._DOM = DOM;
     this._selector = selector;
     this._node = node;
@@ -56,18 +57,18 @@ export default class Layout {
       // * success!
       this.success = true;
     } else {
-      console.assert(this._DOM.getParentNode(this.root) === this._initialRoot, 'Failed to insert the layout root into the DOM.')
-      console.assert(this._DOM.getElementOffsetParent(this.paperFlow) === this.root, 'Failed to insert the paperFlow element into the DOM.')
-      console.assert(this._DOM.getElementOffsetParent(this.contentFlow) === this.root, 'Failed to insert the contentFlow element into the DOM.')
+      this._assert && console.assert(this._DOM.getParentNode(this.root) === this._initialRoot, 'Failed to insert the layout root into the DOM.')
+      this._assert && console.assert(this._DOM.getElementOffsetParent(this.paperFlow) === this.root, 'Failed to insert the paperFlow element into the DOM.')
+      this._assert && console.assert(this._DOM.getElementOffsetParent(this.contentFlow) === this.root, 'Failed to insert the contentFlow element into the DOM.')
       return
     }
 
   }
 
   _getTemplates() {
-    console.assert(this._selector.frontpageTemplate, 'frontpageTemplate selector is missing');
-    console.assert(this._selector.headerTemplate, 'headerTemplate selector is missing');
-    console.assert(this._selector.footerTemplate, 'footerTemplate selector is missing');
+    this._assert && console.assert(this._selector.frontpageTemplate, 'frontpageTemplate selector is missing');
+    this._assert && console.assert(this._selector.headerTemplate, 'headerTemplate selector is missing');
+    this._assert && console.assert(this._selector.footerTemplate, 'footerTemplate selector is missing');
     this.frontpageTemplate = this._DOM.getInnerHTML(this._selector.frontpageTemplate);
     this.headerTemplate = this._DOM.getInnerHTML(this._selector.headerTemplate);
     this.footerTemplate = this._DOM.getInnerHTML(this._selector.footerTemplate);
@@ -95,7 +96,7 @@ export default class Layout {
     } else if (body) {
       this._DOM.insertBefore(body, styleElement);
     } else {
-      console.assert(false, 'We expected to find the HEAD and BODY tags.');
+      this._assert && console.assert(false, 'We expected to find the HEAD and BODY tags.');
     }
   }
 
@@ -179,7 +180,7 @@ export default class Layout {
   _ignoreUnprintableEnvironment(root) {
     if (root === this._DOM.body) {
       // ! now this is impossible, because a new root is created, and always has a parent
-      console.assert(false, "misshapen root")
+      this._assert && console.assert(false, "misshapen root")
       return
     }
 

--- a/src/node.js
+++ b/src/node.js
@@ -9,23 +9,24 @@ export default class Node {
     this._selector = selector;
     // * From config:
     this._debug = config.debugMode ? { ...config.debugConfig.node } : {};
+    this._assert = config.consoleAssert ? true : false;
     this._markupDebugMode = this._config.markupDebugMode;
   }
 
   // GET NODE
 
   get(selector, target = this._DOM) {
-    console.assert(selector);
+    this._debug._ && console.assert(selector);
     return this._DOM.getElement(selector, target)
   }
 
   getAll(selectors, target = this._DOM) {
-    console.assert(selectors);
+    this._debug._ && console.assert(selectors);
     if (typeof selectors === 'string') {
       selectors = selectors.split(',').filter(Boolean);
     }
-    console.assert(Array.isArray(selectors), 'Selectors must be provided as an array or string (one selector or multiple selectors, separated by commas). Now the selectors are:', selectors);
-    console.assert(selectors.length > 0, 'getAll(selectors), selectors:', selectors);
+    this._assert && console.assert(Array.isArray(selectors), 'Selectors must be provided as an array or string (one selector or multiple selectors, separated by commas). Now the selectors are:', selectors);
+    this._debug._ && console.assert(selectors.length > 0, 'getAll(selectors), selectors:', selectors);
 
     if (selectors.length === 1) {
       return [...this._DOM.getAllElements(selectors[0], target)]
@@ -927,7 +928,7 @@ export default class Node {
       } else if (first.match(/[a-zA-Z]/)) {
         element = this._DOM.createElement(selector);
       } else {
-        console.assert(false, `Expected valid html selector ot tag name, but received:`, selector)
+        this._assert && console.assert(false, `Expected valid html selector ot tag name, but received:`, selector)
         return
       }
     }

--- a/src/pages/pages.js
+++ b/src/pages/pages.js
@@ -23,6 +23,7 @@ export default class Pages {
 
     // * From config:
     this._debug = config.debugMode ? { ...config.debugConfig.pages } : {};
+    this._assert = config.consoleAssert ? true : false;
 
     // * Private
     this._selector = selector; // todo one occurrence
@@ -799,7 +800,7 @@ export default class Pages {
           '\n🥁 fullPageFactor', fullPageFactor,
         );
 
-        console.assert(availableSpaceFactor < 1);
+        this._debug._parseNode && console.assert(availableSpaceFactor < 1);
 
         // Try to fit currentElement into the remaining space
         // on the current(last) page (availableSpace).

--- a/src/preview.js
+++ b/src/preview.js
@@ -18,6 +18,7 @@ export default class Preview {
     // * From config:
     this._config = config;
     this._debug = config.debugMode ? { ...config.debugConfig.preview } : {};
+    this._assert = config.consoleAssert ? true : false;
 
     this._DOM = DOM;
     this._selector = selector;
@@ -93,7 +94,7 @@ export default class Preview {
     const _printBodyMaskWindowFirstShift = _printTopMargin + _headerHeight;
     const _maskStep = _printPaperHeight + _virtualPagesGap;
 
-    console.assert(
+    this._assert && console.assert(
       (_printPaperHeight === _bodyHeight + _headerHeight + _printTopMargin + _footerHeight + _printBottomMargin),
       'Paper size calculation params do not match'
     );
@@ -325,7 +326,7 @@ export default class Preview {
     this._DOM.setStyles(balancingFooter, { marginBottom: balancer + 'px' });
 
     // TODO check if negative on large documents
-    this._debug._ && console.assert(balancer >= 0, `balancer is negative: ${balancer} < 0`, contentSeparator);
+    this._assert && console.assert(balancer >= 0, `balancer is negative: ${balancer} < 0`, contentSeparator);
   }
 
 }

--- a/src/validator.js
+++ b/src/validator.js
@@ -12,6 +12,8 @@ export default class Validator {
     this._node = node;
     this._layout = layout;
     this._root = layout.root;
+
+    this._assert = config.consoleAssert ? true : false;
   }
 
   init() {
@@ -31,7 +33,7 @@ export default class Validator {
       return accumulator
     }, []);
 
-    console.assert(!brokenDividers.length, 'Problems with preview generation on the following pages: ', brokenDividers)
+    this._assert && console.assert(!brokenDividers.length, 'Problems with preview generation on the following pages: ', brokenDividers)
 
   }
 }


### PR DESCRIPTION
- Add data-console-assert="true" to user parameters to enable console.assert logging (independent of debug mode).
- Normalize string booleans in config object
- Add function convertStringBools