### PR TITLE
feat(config): add forced debug mode with full-config switch

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,4 @@
 
-import config from './config.js';
-import debugConfig from './debugConfig.js';
 import SELECTOR from './selector.js';
 import DocumentObjectModel from './DOM.js';
 import Layout from './layout.js';
@@ -12,13 +10,16 @@ import Toc from './toc.js';
 import Validator from './validator.js';
 import Preloader from './preloader.js';
 import Preprocess from './preprocess/index.js';
+import isTruthy from './utils/isTruthy.js';
+import buildAppConfig from './appConfig.js';
 
 const CONSOLE_CSS_LABEL = `color:Gray;border:1px solid;`
 
 export default class App {
   constructor(params) {
     this.params = params;
-    this.debugMode = params.debugMode;
+    this.forcedDebugMode = isTruthy(params.forcedDebugMode);
+    this.debugMode = isTruthy(params.debugMode) || this.forcedDebugMode;
     this.preloader = params.preloader;
     this.selector = SELECTOR;
     this.config;
@@ -57,15 +58,16 @@ export default class App {
     // ** Merging the user configuration (config) with the debugging settings (debugConfig).
     // ** This allows centralized management of logging and other debugging options,
     // ** passing them through the config object to all required classes.
-    this.config = {
-      ...config(this.params), // ** Main application configuration
-      debugConfig             // ** Debugging configuration (e.g., logging)
-    };
+    this.config = buildAppConfig(this.params);
     this.debugMode && console.groupEnd();
     this.debugMode && console.info('⚙️ Current config with debugConfig:', this.config);
     this.debugMode && console.timeEnd("⏱️ Config time");
 
-    this.config.consoleAssert && console.info('🧧 Assertions enabled.');
+    // * `this.config.debugConfig.testSignals.forcedModeLog` is FALSE by default,
+    // * and enables by forced debug mode.
+    this.config.debugConfig.testSignals.forcedModeLog && console.info('[HTML2PDF4DOC] 🛠️ Forced debug mode is active.');
+    // * `consoleAssert` enables in user config OR by forced debug mode.
+    this.config.consoleAssert && console.info('[HTML2PDF4DOC] 🧧 Assertions enabled.');
 
     // * prepare helpers
 

--- a/src/appConfig.js
+++ b/src/appConfig.js
@@ -1,0 +1,25 @@
+import config from './config.js';
+import debugConfig, { enableAllDebugFlags } from './debugConfig.js';
+
+// 🤖 Forced debug mode acts like a “god switch”: HTML `data-forced-debug-mode="true"`
+//    1) promotes debug/console/assert/markup flags to true in runtime config
+//    2) clones `debugConfig` with every flag enabled (even nested ones)
+//    3) emits a passport log (`Forced debug mode is active`) when the test signal is enabled
+export default function buildAppConfig(params) {
+  const runtimeConfig = config(params);
+
+  if (runtimeConfig.forcedDebugMode) {
+    runtimeConfig.debugMode = true;
+    runtimeConfig.consoleAssert = true;
+    runtimeConfig.markupDebugMode = true;
+  }
+
+  const resolvedDebugConfig = runtimeConfig.forcedDebugMode
+    ? enableAllDebugFlags(debugConfig)
+    : debugConfig;
+
+  return {
+    ...runtimeConfig,
+    debugConfig: resolvedDebugConfig,
+  };
+}

--- a/src/config.js
+++ b/src/config.js
@@ -13,6 +13,7 @@ export default function createConfig(params) {
     // * in order to display messages in the browser console,
     // * this option can be set to true:
     debugMode: false,
+    forcedDebugMode: false,
     // ** The preloader is only debugged when enabled via user configuration.
 
     // * Assert messages are enabled in the user settings by the parameter

--- a/src/debugConfig.js
+++ b/src/debugConfig.js
@@ -55,6 +55,26 @@ const debugConfig = {
   tableLike: {
     _: false,
   },
+  // * `TEST` group
+  testSignals: {
+    forcedModeLog: false, // * keep always false
+  },
 };
 
+// * Clones the debug matrix but forces every flag to true for global troubleshooting.
+function enableAllDebugFlags(configSection) {
+  const result = Array.isArray(configSection) ? [] : {};
+
+  Object.entries(configSection).forEach(([key, value]) => {
+    if (value && typeof value === 'object') {
+      result[key] = enableAllDebugFlags(value);
+    } else {
+      result[key] = true;
+    }
+  });
+
+  return result;
+}
+
+export { enableAllDebugFlags };
 export default debugConfig;

--- a/src/utils/isTruthy.js
+++ b/src/utils/isTruthy.js
@@ -1,0 +1,3 @@
+const isTruthy = (value) => value === true || value === 'true';
+
+export default isTruthy;

--- a/test/unit/app.test.js
+++ b/test/unit/app.test.js
@@ -1,21 +1,18 @@
 import { expect } from 'chai';
 import { JSDOM } from 'jsdom';
 import App from '../../src/app.js';
-import config from '../../src/config.js';
-import debugConfig from '../../src/debugConfig.js';
+import buildAppConfig from '../../src/appConfig.js';
 
 describe('App class', () => {
   let dom;
 
   beforeEach(() => {
-    // Создаём виртуальное DOM окружение с JSDOM
     dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`);
     global.window = dom.window;
     global.document = dom.window.document;
   });
 
   afterEach(() => {
-    // Убираем глобальные объекты после каждого теста
     delete global.window;
     delete global.document;
   });
@@ -32,28 +29,28 @@ describe('App class', () => {
     });
   });
 
-  // describe('config merging', () => {
-  //   it('should merge config and debugConfig into this.config', async () => {
-  //     const params = { debugMode: true };
-  //     const app = new App(params); // Здесь App должен сам объединить конфигурации
+  describe('buildAppConfig', () => {
+    it('enables asserts and markup flags when forced debug mode is active', () => {
+      const params = { forcedDebugMode: 'true' };
+      const builtConfig = buildAppConfig(params);
 
-  //     // Уберите вызов DOMContentLoaded, чтобы проверить логику
-  //     // напрямую (временно).
-  //     app.config = { ...config(params), debugConfig };
+      expect(builtConfig.forcedDebugMode).to.be.true;
+      expect(builtConfig.debugMode).to.be.true;
+      expect(builtConfig.consoleAssert).to.be.true;
+      expect(builtConfig.markupDebugMode).to.be.true;
+      expect(builtConfig.debugConfig.testSignals.forcedModeLog).to.be.true;
+    });
 
-  //     // Ожидаемая структура config
-  //     const expectedConfig = {
-  //       ...config(params),
-  //       debugConfig,
-  //     };
+    it('keeps test signal disabled without forced debug mode', () => {
+      const params = { debugMode: 'true' };
+      const builtConfig = buildAppConfig(params);
 
-  //     // Проверяем, что ключи совпадают
-  //     expect(app.config).to.have.keys(Object.keys(expectedConfig));
+      expect(builtConfig.forcedDebugMode).to.be.false;
+      expect(builtConfig.debugMode).to.be.true;
+      expect(builtConfig.consoleAssert).to.be.false;
+      expect(builtConfig.markupDebugMode).to.be.false;
+      expect(builtConfig.debugConfig.testSignals.forcedModeLog).to.be.false;
+    });
+  });
 
-  //     // // Проверяем значения
-  //     // Object.keys(expectedConfig).forEach((key) => {
-  //     //   expect(app.config[key]).to.deep.equal(expectedConfig[key]);
-  //     // });
-  //   });
-  // });
 });


### PR DESCRIPTION
- add `data-forced-debug-mode` plumbing that promotes debug/assert/markup flags and feeds modules an all-true debugConfig clone
- surface Selenium-friendly passport log via `testSignals.forcedModeLog`
- refactor App helpers (config builder, isTruthy) into dedicated modules to keep entrypoint slim
- extend/debug unit tests to cover forced-mode config semantics

Closes #131