### PR TITLE
fix(styles): make text-line inline-block during calculations

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -259,14 +259,15 @@ ${SELECTOR.textGroup} {
   display: block;
 }
 
-/*${SELECTOR.split} ${SELECTOR.textGroup} {
-  display: inline;
-}*/
-
-${SELECTOR.complexTextBlock} > ${SELECTOR.textLine} {
-  /* Firefox and inconsistent values of offset top for inline element */
+${SELECTOR.textLine} {
+  /*
+    - Firefox and inconsistent values of offset top for inline element
+    - Visually, the string fits, but the inline baseline gap below the string
+      causes a compensator + assertions.
+      'display: inline-block' removes spaces between parts of the string,
+      but it should leave the text inline in media print.
+  */
   display: inline-block;
-  // TODO: it removes spaces between parts of the string, it should leave the text inline after processing.
 }
 
 ${SELECTOR.textGroup} ${SELECTOR.textLine} {
@@ -339,6 +340,15 @@ ${SELECTOR.printForcedPageBreak} {
     FIX the split of complex blocks and check in Firefox.
     */
     /* break-inside: avoid-page; */
+  }
+
+  ${SELECTOR.textLine} {
+    /*
+      - Visually, the string fits, but the inline baseline gap below the string
+        causes a compensator + assertions.
+      - should leave the text inline after processing.
+    */
+    display: inline;
   }
 }
 

--- a/test/end2end/9999_strictdoc_load/admonition-1/20251011_182559.html
+++ b/test/end2end/9999_strictdoc_load/admonition-1/20251011_182559.html
@@ -104,7 +104,7 @@
                         <p class="last">After the existing JUnit XML flavors have been implemented, it should be easy to
                           add more tools in case their output differs.</p>
                       </div>
-                      <div class="admonition warning">
+                      <div class="admonition warning" data-testid="admonition-warning-title">
                         <p class="first admonition-title">Warning</p>
                         <p class="last">The JUnit XML feature's status is experimental. The functionality has been
                           implemented and passes basic integration tests but it has not received enough testing by the

--- a/test/end2end/9999_strictdoc_load/admonition-1/test_case.py
+++ b/test/end2end/9999_strictdoc_load/admonition-1/test_case.py
@@ -8,8 +8,12 @@ path_to_this_test_file_folder = os.path.dirname(os.path.abspath(__file__))
 case01_html_file_url = (
     "file:///" + os.path.join(path_to_this_test_file_folder, "20251011_164949.html")
 )
+case02_html_file_url = (
+    "file:///" + os.path.join(path_to_this_test_file_folder, "20251011_182559.html")
+)
 
 problematic = '//*[@data-testid="problematic"]'
+admonition_warning_title = '//*[@data-testid="admonition-warning-title"]'
 
 class Test(BaseCase):
     def __init__(self, *args, **kwargs):
@@ -22,3 +26,10 @@ class Test(BaseCase):
         self.helper.assert_document_has_pages(3)
         self.helper.assert_element_on_the_page(problematic, 3)
         self.helper.assert_element_starts_page(problematic, 3)
+
+    def test_02(self):
+        # 2 pages
+        # inside border
+        self.helper.do_open(case02_html_file_url)
+        self.helper.assert_document_has_pages(2)
+        self.helper.assert_element_on_the_page(admonition_warning_title, 1)


### PR DESCRIPTION
fix(styles): make text-line inline-block during calculations and return inline when printing

    - Visually, the string fits, but the inline baseline gap below the string causes a compensator + assertions. 'display: inline-block' removes spaces between parts of the string, but it should leave the text inline in media print.