### PR TITLE
refactor(markers): rename flags/flag-store to mark*

### DIFF
--- a/docs/GRID_SPLIT_EDGE_CASES.md
+++ b/docs/GRID_SPLIT_EDGE_CASES.md
@@ -49,7 +49,7 @@ Goal: map out grid-specific risks before we extend the splitter beyond simple mo
 ## 8. Nested grids / absolute positioning
 - **Nested grids**: treat inner grids as normal children; monitor heights.
 - **Absolute positioned items**: height = 0 → may disappear from layout.
-- **Strategy**: if child has `position:absolute`, consider moving it along but warn. For nested grids, ensure they carry `flagNoBreak` to avoid splitting inside inadvertently.
+- **Strategy**: if child has `position:absolute`, consider moving it along but warn. For nested grids, ensure they carry `markNoBreak` to avoid splitting inside inadvertently.
 
 ## 9. Content that cannot be broken
 - **Examples**: large images/SVG, charts.

--- a/docs/MARKERS.md
+++ b/docs/MARKERS.md
@@ -9,34 +9,34 @@ It separates internal logic from debug/test DOM attributes.
 - Provide optional, explicit DOM markers for debug and tests.
 
 ## Core Concepts
-- **Flags**: logical markers stored in an internal WeakMap (not in the DOM).
+- **Marks**: logical markers stored in an internal WeakMap (not in the DOM).
 - **Registry**: indexed collections for structural markers (pageStart/pageEnd/pageNumber).
 - **DOM attributes**: written only in debug/test mode.
 
 ## Modes
-- **Normal**: flags + registry only (no DOM attributes).
+- **Normal**: marks + registry only (no DOM attributes).
 - **Debug/Test**: DOM attributes are written when `data-markup-debug-mode="true"`.
 
-## Flag Categories
+## Mark Categories
 - **runtime-only**: used by logic only; never required in DOM.
 - **structural**: pageStart/pageEnd/pageNumber; also registered in the registry.
 - **debug-only**: visual hints (e.g. processed), only meaningful in DOM.
 
-Flag definitions live in `src/node/markers/defs.js`.
+Mark definitions live in `src/node/markers/defs.js`.
 
 ## How to Write Markers
-Use marker helpers (preferred) or `setFlag` directly:
+Use marker helpers (preferred) or `setMark` directly:
 - Marker helpers live in `src/node/markers/`.
-- `setFlag`/`clearFlag` live in `src/node/markers/api.js`.
+- `setMark`/`clearMark` live in `src/node/markers/api.js`.
 
 Example:
 ```js
-this.setFlag(element, 'noHanging');
-this.markPageStartElement(element, pageNum);
+this.setMark(element, 'noHanging');
+this.markPageStart(element, pageNum);
 ```
 
 ## How to Read Markers
-- Use selectors helpers (e.g. `isNoBreak`, `isSlice`) which read from flags.
+- Use selectors helpers (e.g. `isNoBreak`, `isSlice`) which read from marks.
 - For structural markers, use the registry:
   - `getRegisteredPageEnds()`
   - `getRegisteredPageNumberForElement(element)`
@@ -51,5 +51,5 @@ Enable them via HTML:
 ```
 
 ## Contract Summary
-- Logic reads flags/registry, not DOM attributes.
+- Logic reads marks/registry, not DOM attributes.
 - DOM attributes are optional and must not be required by the algorithm.

--- a/src/config.js
+++ b/src/config.js
@@ -21,7 +21,7 @@ export default function createConfig(params) {
     // * By default is disabled.
     consoleAssert: false,
 
-    // * Visual flags on processed DOM elements (affects performance)
+    // * Visual marks on processed DOM elements (affects performance)
     // * are enabled in user settings using the parameter
     // * data-markup-debug-mode=“true”.
     // * Disabled by default.

--- a/src/node/elements/grid.js
+++ b/src/node/elements/grid.js
@@ -549,12 +549,12 @@ export default class Grid {
       getOriginalCells: () => [...row],
       getShellHeights: () => self._getGridShellHeights(row, cellStyles),
       markOriginalRow: ({ cells }) => {
-        cells.forEach(cell => self._node.setFlagSlice(cell));
+        cells.forEach(cell => self._node.markSlice(cell));
       },
       beginRow: () => ({ fragment: self._DOM.createDocumentFragment(), cells: [] }),
       cloneCellFallback: (originalCell) => self._DOM.cloneNodeWrapper(originalCell),
       handleCell: ({ context, cellClone }) => {
-        self._node.setFlagSlice(cellClone);
+        self._node.markSlice(cellClone);
         context.fragment.append(cellClone);
         context.cells.push(cellClone);
       },
@@ -711,7 +711,7 @@ export default class Grid {
     // We do not wrap with createWithFlagNoBreak to avoid CSS breakage; clone wrapper instead.
     const part = this._DOM.cloneNodeWrapper(node);
     this._node.copyNodeWidth(part, node);
-    this._node.setFlagNoBreak(part);
+    this._node.markNoBreak(part);
 
     if (startId) {
       // * normalize top cut for table slices
@@ -773,7 +773,7 @@ export default class Grid {
     // ? may affect the table design
     // todo: include in user config
     this._node.markTopCut(finalPart);
-    this._node.setFlagNoBreak(finalPart);
+    this._node.markNoBreak(finalPart);
 
     const currentRows = entries?.currentRows || this._currentGridRows || [];
     const telemetryRows = this._collectGridTelemetryRows(currentRows, startId);

--- a/src/node/elements/paragraph.js
+++ b/src/node/elements/paragraph.js
@@ -52,7 +52,7 @@ export default class Paragraph {
       return []
     }
 
-    if (this._node.hasFlag(node, 'split')) {
+    if (this._node.hasMark(node, 'split')) {
       // * This node has already been processed and has lines and groups of lines inside it,
 
       this.logGroupEnd(this._selector.split);
@@ -214,7 +214,7 @@ export default class Paragraph {
 
     this.logGroupEnd('OK _splitComplexTextBlockIntoLines');
 
-    this._node.setFlag(node, 'split');
+    this._node.setMark(node, 'split');
 
     return linedChildren
   }

--- a/src/node/markers/api.js
+++ b/src/node/markers/api.js
@@ -1,50 +1,50 @@
 // 📦 markers helpers
 
-import { FLAG_DEFS } from './defs.js';
+import { MARK_DEFS } from './defs.js';
 
 /**
  * @this {Node}
  */
-export function setFlag(element, key, value, options = {}) {
-  const flagConfig = this._getFlagAttributeConfig?.(key);
-  const forceAttribute = this._isStyleFlag?.(key);
+export function setMark(element, key, value, options = {}) {
+  const markConfig = this._getMarkAttributeConfig?.(key);
+  const forceAttribute = this._isStyleMark?.(key);
   const mergedOptions = {
-    ...flagConfig,
+    ...markConfig,
     ...(forceAttribute ? { forceAttribute: true } : {}),
     ...options,
   };
-  this._flags.set(element, key, value, mergedOptions);
-  this._registerFlag?.(element, key, value);
+  this._marks.set(element, key, value, mergedOptions);
+  this._registerMark?.(element, key, value);
 }
 
 /**
  * @this {Node}
  */
-export function getFlag(element, key) {
-  return this._flags.get(element, key);
+export function getMark(element, key) {
+  return this._marks.get(element, key);
 }
 
 /**
  * @this {Node}
  */
-export function hasFlag(element, key) {
-  return this._flags.has(element, key);
+export function hasMark(element, key) {
+  return this._marks.has(element, key);
 }
 
 /**
  * @this {Node}
  */
-export function clearFlag(element, key, options) {
-  const forceAttribute = this._isStyleFlag?.(key);
+export function clearMark(element, key, options) {
+  const forceAttribute = this._isStyleMark?.(key);
   const mergedOptions = forceAttribute ? { ...options, forceAttribute: true } : options;
-  this._flags.clear(element, key, mergedOptions);
-  this._unregisterFlag?.(element, key);
+  this._marks.clear(element, key, mergedOptions);
+  this._unregisterMark?.(element, key);
 }
 
 /**
  * @this {Node}
  */
-// Internal registry helpers (used only via setFlag/clearFlag).
+// Internal registry helpers (used only via setMark/clearMark).
 function registerPageStart(element, pageNum) {
   if (!element) return;
   this._markers.registry.pageStart.set(Number(pageNum), element);
@@ -119,9 +119,9 @@ export function getRegisteredPageNumberForElement(element) {
 /**
  * @this {Node}
  */
-export function _registerFlag(element, key, value) {
+export function _registerMark(element, key, value) {
   if (!element) return;
-  const def = FLAG_DEFS[key];
+  const def = MARK_DEFS[key];
   if (!def || !def.registry) return;
   switch (def.registry) {
     case 'pageStart':
@@ -141,9 +141,9 @@ export function _registerFlag(element, key, value) {
 /**
  * @this {Node}
  */
-export function _unregisterFlag(element, key) {
+export function _unregisterMark(element, key) {
   if (!element) return;
-  const def = FLAG_DEFS[key];
+  const def = MARK_DEFS[key];
   if (!def || !def.registry) return;
   switch (def.registry) {
     case 'pageStart':
@@ -185,8 +185,8 @@ export function getRegisteredPageEnds() {
 /**
  * @this {Node}
  */
-export function _getFlagAttributeConfig(key) {
-  const def = FLAG_DEFS[key];
+export function _getMarkAttributeConfig(key) {
+  const def = MARK_DEFS[key];
   if (!def || !def.selectorKey) return undefined;
   const attributeSelector = this._selector[def.selectorKey];
   if (!attributeSelector) return undefined;
@@ -199,6 +199,6 @@ export function _getFlagAttributeConfig(key) {
 /**
  * @this {Node}
  */
-export function _isStyleFlag(key) {
-  return FLAG_DEFS[key]?.kind === 'style';
+export function _isStyleMark(key) {
+  return MARK_DEFS[key]?.kind === 'style';
 }

--- a/src/node/markers/defs.js
+++ b/src/node/markers/defs.js
@@ -1,4 +1,4 @@
-export const FLAG_DEFS = {
+export const MARK_DEFS = {
   // ✴️ structural
   // * needs fast lookup by key (e.g., page number), so it is indexed in registry.
   // * DOM attributes are written only in debug/test.
@@ -6,7 +6,7 @@ export const FLAG_DEFS = {
   pageEnd: { kind: 'structural', selectorKey: 'pageEndMarker', registry: 'pageEnd' },
   pageNumber: { kind: 'structural', selectorKey: 'pageMarker', registry: 'pageNumber' },
   // ✴️ runtime-only
-  // * local logic flags; read via hasFlag(element, key). No registry or global lookup is needed.
+  // * local logic marks; read via hasMark(element, key). No registry or global lookup is needed.
   // * DOM attributes are written only in debug/test.
   noBreak: { kind: 'runtime', selectorKey: 'flagNoBreak' },
   noHanging: { kind: 'runtime', selectorKey: 'flagNoHanging' },

--- a/src/node/markers/markStore.js
+++ b/src/node/markers/markStore.js
@@ -1,9 +1,9 @@
-// Flag storage with WeakMap base and optional Symbol/attribute mirrors.
+// Mark storage with WeakMap base and optional Symbol/attribute mirrors.
 // Attributes are written only when markupDebugMode is enabled or forceAttribute is true.
 
 const DEFAULT_VALUE = true;
 
-export default class FlagStore {
+export default class MarkStore {
   constructor({
     debugMode = false,
     markupDebugMode = false,
@@ -14,7 +14,7 @@ export default class FlagStore {
     this._markupDebugMode = Boolean(markupDebugMode);
     this._setAttribute = setAttribute;
     this._removeAttribute = removeAttribute;
-    this._flags = new WeakMap();
+    this._marks = new WeakMap();
     this._symbols = new Map();
   }
 
@@ -31,21 +31,21 @@ export default class FlagStore {
   }
 
   get(element, key) {
-    const entry = this._flags.get(element);
+    const entry = this._marks.get(element);
     return entry ? entry.get(key) : undefined;
   }
 
   has(element, key) {
-    const entry = this._flags.get(element);
+    const entry = this._marks.get(element);
     return Boolean(entry && entry.has(key));
   }
 
   clear(element, key, options = {}) {
     if (!element || !key) return;
-    const entry = this._flags.get(element);
+    const entry = this._marks.get(element);
     if (entry) {
       entry.delete(key);
-      if (entry.size === 0) this._flags.delete(element);
+      if (entry.size === 0) this._marks.delete(element);
     }
 
     if (this._debugMode) {
@@ -57,10 +57,10 @@ export default class FlagStore {
   }
 
   _getEntry(element) {
-    let entry = this._flags.get(element);
+    let entry = this._marks.get(element);
     if (!entry) {
       entry = new Map();
-      this._flags.set(element, entry);
+      this._marks.set(element, entry);
     }
     return entry;
   }

--- a/src/node/markers/readers.js
+++ b/src/node/markers/readers.js
@@ -2,26 +2,26 @@
  * @this {Node}
  */
 export function isPageStart(element) {
-  return this.hasFlag(element, 'pageStart');
+  return this.hasMark(element, 'pageStart');
 }
 
 /**
  * @this {Node}
  */
 export function isNoBreak(element) {
-  return this.hasFlag(element, 'noBreak');
+  return this.hasMark(element, 'noBreak');
 }
 
 /**
  * @this {Node}
  */
 export function isNoHanging(element) {
-  return this.hasFlag(element, 'noHanging');
+  return this.hasMark(element, 'noHanging');
 }
 
 /**
  * @this {Node}
  */
 export function isSlice(element) {
-  return this.hasFlag(element, 'slice');
+  return this.hasMark(element, 'slice');
 } // todo: check after migrate to all-split strategy

--- a/src/node/markers/state.js
+++ b/src/node/markers/state.js
@@ -1,12 +1,12 @@
-import FlagStore from './flagStore.js';
+import MarkStore from './markStore.js';
 import MarkersRegistry from './registry.js';
 
 // Central markers state:
-// - flags: logical markers (WeakMap + optional Symbol/attributes)
+// - marks: logical markers (WeakMap + optional Symbol/attributes)
 // - registry: structural markers (pageStart/pageEnd/pageNumber)
 export default class MarkersState {
-  constructor(flagOptions = {}) {
-    this.flags = new FlagStore(flagOptions);
+  constructor(markOptions = {}) {
+    this.marks = new MarkStore(markOptions);
     this.registry = new MarkersRegistry();
   }
 }

--- a/src/node/markers/writers.js
+++ b/src/node/markers/writers.js
@@ -7,57 +7,57 @@ const _isDebug = debugFor('markers');
  * @this {Node}
  */
 export function markProcessed(element, value) {
-  this.setFlag(element, 'processed', value);
+  this.setMark(element, 'processed', value);
 }
 
 
 /**
  * @this {Node}
  */
-export function setFlagNoBreak(element) {
-  this.setFlag(element, 'noBreak');
+export function markNoBreak(element) {
+  this.setMark(element, 'noBreak');
 }
 
 /**
  * @this {Node}
  */
-export function setFlagNoHanging(element, value) {
-  this.setFlag(element, 'noHanging', value);
+export function markNoHanging(element, value) {
+  this.setMark(element, 'noHanging', value);
 }
 
 /**
  * @this {Node}
  */
-export function setFlagSlice(element) {
-  this.setFlag(element, 'slice');
+export function markSlice(element) {
+  this.setMark(element, 'slice');
 }
 
 /**
  * @this {Node}
  */
-export function markPageStartElement(element, pageNum) {
-  this.setFlag(element, 'pageStart', pageNum);
+export function markPageStart(element, pageNum) {
+  this.setMark(element, 'pageStart', pageNum);
 }
 
 /**
  * @this {Node}
  */
-export function unmarkPageStartElement(element) {
-  this.clearFlag(element, 'pageStart');
+export function unmarkPageStart(element) {
+  this.clearMark(element, 'pageStart');
 }
 
 /**
  * @this {Node}
  */
-export function markPageEndElement(element, pageNum) {
-  this.setFlag(element, 'pageEnd', pageNum);
+export function markPageEnd(element, pageNum) {
+  this.setMark(element, 'pageEnd', pageNum);
 }
 
 /**
  * @this {Node}
  */
 export function markPageNumber(element, pageNum) {
-  this.setFlag(element, 'pageNumber', pageNum);
+  this.setMark(element, 'pageNumber', pageNum);
 }
 
 /**
@@ -65,7 +65,7 @@ export function markPageNumber(element, pageNum) {
  */
 export function markCleanTopCut(element) {
   _isDebug(this) && console.log('[mark ⊤ cut]', element);
-  element && this.setFlag(element, 'cleanTopCut');
+  element && this.setMark(element, 'cleanTopCut');
 }
 
 /**
@@ -73,7 +73,7 @@ export function markCleanTopCut(element) {
  */
 export function markCleanBottomCut(element) {
   _isDebug(this) && console.log('[mark ⊥ cut]', element);
-  element && this.setFlag(element, 'cleanBottomCut');
+  element && this.setMark(element, 'cleanBottomCut');
 }
 
 /**
@@ -81,7 +81,7 @@ export function markCleanBottomCut(element) {
  */
 export function markTopCut(element) {
   _isDebug(this) && console.log('[mark ⊤ cut]', element);
-  element && this.setFlag(element, 'topCut');
+  element && this.setMark(element, 'topCut');
 }
 
 /**
@@ -89,7 +89,7 @@ export function markTopCut(element) {
  */
 export function markBottomCut(element) {
   _isDebug(this) && console.log('[mark ⊥ cut]', element);
-  element && this.setFlag(element, 'bottomCut');
+  element && this.setMark(element, 'bottomCut');
 }
 
 /**

--- a/src/node/modules/creators.js
+++ b/src/node/modules/creators.js
@@ -77,7 +77,7 @@ export function createTextGroup() {
  */
 export function createWithFlagNoBreak(style) {
   const element = this.create();
-  this.setFlagNoBreak(element);
+  this.markNoBreak(element);
   style && this._DOM.setStyles(element, style);
   return element;
 }
@@ -150,7 +150,7 @@ export function createSignpost(text, height) {
     height: height + 'px',
   });
   text && this._DOM.setInnerHTML(prefix, text);
-  this.setFlagNoBreak(prefix);
+  this.markNoBreak(prefix);
   return prefix
 }
 
@@ -183,7 +183,7 @@ export function createSliceWrapper(node) {
   const wrapper = this._DOM.cloneNodeWrapper(node);
   // * The clone should be always cleared;
   // * the possible page start mark remains on the first chunk.
-  this.unmarkPageStartElement(wrapper);
-  this.setFlagNoBreak(wrapper);
+  this.unmarkPageStart(wrapper);
+  this.markNoBreak(wrapper);
   return wrapper
 }

--- a/src/node/modules/getters.js
+++ b/src/node/modules/getters.js
@@ -449,22 +449,22 @@ export function getTableEntries(node) {
     }
 
     if (tag === 'CAPTION') {
-      this.setFlagNoBreak(curr);
+      this.markNoBreak(curr);
       return { ...acc, caption: curr };
     }
 
     if (tag === 'COLGROUP') {
-      this.setFlagNoBreak(curr);
+      this.markNoBreak(curr);
       return { ...acc, colgroup: curr };
     }
 
     if (tag === 'THEAD') {
-      this.setFlagNoBreak(curr);
+      this.markNoBreak(curr);
       return { ...acc, thead: curr };
     }
 
     if (tag === 'TFOOT') {
-      this.setFlagNoBreak(curr);
+      this.markNoBreak(curr);
       return { ...acc, tfoot: curr };
     }
 

--- a/src/node/modules/pagination/resolution.js
+++ b/src/node/modules/pagination/resolution.js
@@ -220,9 +220,9 @@ function createDefaultRowAdapter({ row, rowIndex, decorateRowSlice }) {
     ),
     markOriginalRow: ({ cells }) => {
       if (isArrayRow) {
-        // cells.forEach(cell => self.setFlagSlice(cell));
+        // cells.forEach(cell => self.markSlice(cell));
       } else {
-        self.setFlagSlice(row);
+        self.markSlice(row);
       }
     },
     // * beginRow is the starter template for each future slice.
@@ -239,7 +239,7 @@ function createDefaultRowAdapter({ row, rowIndex, decorateRowSlice }) {
     cloneCellFallback: (origCell) => self._DOM.cloneNodeWrapper(origCell),
     handleCell: ({ context, cellClone }) => {
       if (isArrayRow) {
-        self.setFlagSlice(cellClone);
+        self.markSlice(cellClone);
         context.cells.push(cellClone);
       } else {
         self._DOM.insertAtEnd(context.rowWrapper, cellClone);

--- a/src/node/node.js
+++ b/src/node/node.js
@@ -53,7 +53,7 @@ export default class Node {
       setAttribute: this._DOM.setAttribute.bind(this._DOM),
       removeAttribute: this._DOM.removeAttribute.bind(this._DOM),
     });
-    this._flags = this._markers.flags;
+    this._marks = this._markers.marks;
     this._cache = new CacheState();
 
     Object.assign(this, Logging);

--- a/src/pages/pages.js
+++ b/src/pages/pages.js
@@ -129,10 +129,10 @@ export default class Pages {
     if (selectors.length) {
       const elements = this._node.resolveConfigSelectorConstraints(selectors, this._contentFlow, 'noHangings');
       elements.forEach(element => {
-        this._node.setFlagNoHanging(element);
+        this._node.markNoHanging(element);
         const lastChildParent = this._node.findLastChildParent(element, this._contentFlow)
         if (lastChildParent) {
-          this._node.setFlagNoHanging(lastChildParent, 'parent');
+          this._node.markNoHanging(lastChildParent, 'parent');
         }
       });
       this._debug._ && elements.length && console.log('✓ noHangings got the flag');
@@ -142,7 +142,7 @@ export default class Pages {
   _prepareNoBreakElements(selectors) {
     if (selectors.length) {
       const elements = this._node.resolveConfigSelectorConstraints(selectors, this._contentFlow, 'noBreaks');
-      elements.forEach(element => this._node.setFlagNoBreak(element));
+      elements.forEach(element => this._node.markNoBreak(element));
       this._debug._ && elements.length && console.log('✓ noBreaks got the flag');
     }
   }
@@ -339,7 +339,7 @@ export default class Pages {
       pageTop: pageTop,
       prevPageEnd: prevPageEnd,
     });
-    this._node.markPageStartElement(pageStart, this.pages.length);
+    this._node.markPageStart(pageStart, this.pages.length);
     this._debug._registerPageStart && console.log(
       `%c📍register page ${this.pages.length}`, "background:yellow;font-weight:bold",
       '\n  improved result:', improveResult,
@@ -770,7 +770,7 @@ export default class Pages {
         // svg has not offset props
         const isSvgMedia = this._node.isSVG(mediaElement);
         const currentImage = isSvgMedia
-        // TODO replace with setFlag... and remove wrapper function
+        // TODO replace with setMark... and remove wrapper function
         // TODO process at the beginning, find all SVG and set Flag
           ? this._node.createSignpost(mediaElement)
           : mediaElement;

--- a/src/preview.js
+++ b/src/preview.js
@@ -255,7 +255,7 @@ export default class Preview {
     }
 
     if (previousPageLastElement) {
-      // this._node.markPageEndElement(previousPageLastElement, pageIndex + 'test');
+      // this._node.markPageEnd(previousPageLastElement, pageIndex + 'test');
       this._DOM.setStyles(previousPageLastElement, {'margin-bottom': ['0', 'important']});
     } else {
       (pageIndex > 0) && this._debug._ && console.warn(`[preview] There is no page end element before ${pageIndex}. Perhaps it's a 'beginningTail'.`, )
@@ -289,8 +289,8 @@ export default class Preview {
     // * The frontpage will move the previously set `pageStart` markers forward by 1.
     // * If there is no frontpage, `pageStart` markers do not need to be updated.
     // * `pageEnd` markers are set for the first time.
-    this._hasFrontPage && this._node.markPageStartElement(this._pages[pageIndex].pageStart, `${pageIndex + 1}`);
-    this._node.markPageEndElement(this._pages[pageIndex].pageEnd, `${pageIndex + 1}`);
+    this._hasFrontPage && this._node.markPageStart(this._pages[pageIndex].pageStart, `${pageIndex + 1}`);
+    this._node.markPageEnd(this._pages[pageIndex].pageEnd, `${pageIndex + 1}`);
   }
 
   _insertPaper(paperFlow, paper, separator) {

--- a/src/selector.js
+++ b/src/selector.js
@@ -100,7 +100,7 @@ const SELECTOR = {
   textGroup: 'html2pdf4doc-text-group',
   complexTextBlock: 'html2pdf4doc-complex-text-block',
   printForcedPageBreak: 'html2pdf4doc-print-forced-page-break',
-  // * Service flags (are created in the process):
+  // * Service marks (are created in the process):
   split: '[html2pdf4doc-split]',
   processed: '[html2pdf4doc-processed]',
 


### PR DESCRIPTION
- Rename flag storage and APIs to “marks” to reflect non-boolean metadata.
- Update all call sites, docs, and comments to the new terminology.
- Keep behavior unchanged; only naming and interfaces are updated.