### PR TITLE
Pagination: ignore empty spacer <p> and apply its hide mutation in deferred Preview queue

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -14,6 +14,7 @@ import isTruthy from './utils/isTruthy.js';
 import buildAppConfig from './appConfig.js';
 import { normalizeLegacyConfigParams } from './config.js';
 import { forceLayoutParticipation } from './utils/forceLayoutParticipation.js';
+import { createMutationQueue } from './mutations/queue.js';
 
 const CONSOLE_CSS_LABEL = `color:Gray;border:1px solid;`
 
@@ -158,6 +159,8 @@ export default class App {
 
     this.debugMode && console.time("⏱️ Pages time");
     this.debugMode && console.group('%c Pages ', CONSOLE_CSS_LABEL); // Collapsed
+    // Defer selected DOM writes from pagination and apply them in Preview stage.
+    const mutationQueue = createMutationQueue();
     const pages = new Pages({
       config: this.config,
       DOM: DOM,
@@ -166,6 +169,7 @@ export default class App {
       layout: layout,
       referenceHeight: paper.bodyHeight,
       referenceWidth: paper.bodyWidth,
+      mutationQueue,
     }).calculate();
     this.debugMode && console.groupEnd();
     this.debugMode && console.timeEnd("⏱️ Pages time");
@@ -182,6 +186,7 @@ export default class App {
       layout: layout,
       paper: paper,
       pages: pages,
+      mutationQueue,
     }).create();
     this.debugMode && console.groupEnd();
     this.debugMode && console.timeEnd("⏱️ Preview time");

--- a/src/mutations/commands.js
+++ b/src/mutations/commands.js
@@ -1,0 +1,14 @@
+/**
+ * Creates a mutation that hides an ignorable spacer paragraph.
+ */
+export function createHideIgnorableSpacerParagraphMutation({ DOM, element }) {
+  return function hideIgnorableSpacerParagraph() {
+    if (!DOM || !element) {
+      return;
+    }
+    DOM.setStyles(element, { display: ['none', 'important'] });
+    // Debug marker to visually confirm deferred hiding in dev scenarios.
+    DOM.addClasses(element, '🕶️');
+  };
+}
+

--- a/src/mutations/queue.js
+++ b/src/mutations/queue.js
@@ -1,0 +1,28 @@
+// Queue of deferred DOM mutations.
+// Mutations are registered during calculations and applied later in Preview.
+
+/**
+ * Creates a simple in-memory queue for deferred DOM mutation functions.
+ */
+export function createMutationQueue() {
+  const pendingMutations = [];
+
+  return {
+    // Register a mutation function for later execution.
+    enqueue(mutationFn) {
+      if (typeof mutationFn !== 'function') {
+        return;
+      }
+      pendingMutations.push(mutationFn);
+    },
+
+    // Apply all queued mutations in registration order and clear the queue.
+    flush() {
+      for (const mutationFn of pendingMutations) {
+        mutationFn();
+      }
+      pendingMutations.length = 0;
+    },
+  };
+}
+

--- a/src/pages/pages.js
+++ b/src/pages/pages.js
@@ -317,9 +317,10 @@ export default class Pages {
 
     if (this._node.isIgnorableSpacerParagraph(element)) {
       this._debug._registerPageStart && console.log(`🚩 [registerAsPageStart] pageStart candidate is an ignorable spacer paragraph. SKIP registering.`, element);
-      // TODO: defer mutation to the end of the algorithm, and do it in batch, to avoid multiple forced reflows.
-      this._DOM.setStyles(element, {'display': ['none', 'important']});
-      this._DOM.addClasses(element, '🕶️');
+      // Register deferred DOM write: this paragraph is ignored as page-start and hidden later in Preview.
+      this._mutationQueue?.enqueue(
+        createHideIgnorableSpacerParagraphMutation({ DOM: this._DOM, element })
+      );
       return
     }
 

--- a/src/pages/pages.js
+++ b/src/pages/pages.js
@@ -1,5 +1,6 @@
 import arrayFromString from './arrayFromString.js';
 import * as Logging from '../utils/logging.js';
+import { createHideIgnorableSpacerParagraphMutation } from '../mutations/commands.js';
 
 const CONSOLE_CSS_COLOR_PAGES = '#66CC00';
 const CONSOLE_CSS_PRIMARY_PAGES = `color: ${CONSOLE_CSS_COLOR_PAGES};font-weight:bold`;
@@ -18,7 +19,8 @@ export default class Pages {
     selector,
     layout,
     referenceWidth,
-    referenceHeight
+    referenceHeight,
+    mutationQueue,
   }) {
 
     Object.assign(this, Logging);
@@ -48,6 +50,7 @@ export default class Pages {
 
     this._referenceWidth = referenceWidth;
     this._referenceHeight = referenceHeight;
+    this._mutationQueue = mutationQueue;
 
     // todo
     // 1) move to config

--- a/src/pages/pages.js
+++ b/src/pages/pages.js
@@ -312,6 +312,14 @@ export default class Pages {
       return
     };
 
+    if (this._node.isIgnorableSpacerParagraph(element)) {
+      this._debug._registerPageStart && console.log(`🚩 [registerAsPageStart] pageStart candidate is an ignorable spacer paragraph. SKIP registering.`, element);
+      // TODO: defer mutation to the end of the algorithm, and do it in batch, to avoid multiple forced reflows.
+      this._DOM.setStyles(element, {'display': ['none', 'important']});
+      this._DOM.addClasses(element, '🕶️');
+      return
+    }
+
     let pageStart = element;
 
     if (improveResult) {

--- a/src/preview.js
+++ b/src/preview.js
@@ -14,6 +14,7 @@ export default class Preview {
     pages,
     layout,
     paper,
+    mutationQueue,
   }) {
 
     // * From config:
@@ -46,12 +47,15 @@ export default class Preview {
     this._paperFlow = layout.paperFlow;
     this._overlayFlow = layout.overlayFlow;
     this._paper = paper;
+    this._mutationQueue = mutationQueue;
 
     this._hasFrontPage = !!layout.frontpageTemplate;
 
   }
 
   create() {
+    // Apply deferred DOM mutations registered during pagination calculations.
+    this._mutationQueue?.flush();
     this._processFrontPage();
     this._processPages();
     (this._config.mask === true || this._config.mask === 'true') && this._addMask();

--- a/test/end2end/1009_spetial_cases_/case_p_br.html
+++ b/test/end2end/1009_spetial_cases_/case_p_br.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="">
+<head>
+  <meta charset="utf-8">
+  <title>case_chain_equal_bottom</title>
+  <link rel="stylesheet" href="../../shared/css/main.css">
+
+  <script defer
+          data-debug-mode="true"
+          data-markup-debug-mode="true"
+          data-console-assert="true"
+          data-print-height='300px'
+          data-print-width='600px'
+          data-print-left-margin= '50px'
+          data-print-right-margin= '50px'
+          data-print-top-margin= '50px'
+          data-print-bottom-margin= '50px'
+          data-print-font-size='16px'
+          data-page-break-before-selectors="H1"
+          src="../../../dist/bundle.js"></script>
+</head>
+<body>
+  <!-- 1st page -->
+  <div data-testid="first" style="height:200px; background: #e3e6b3"">full page</div>
+  <!-- 2nd page -->
+  <p data-testid="p"><br></p>
+  <h1 data-testid="h1">Header</h1>
+  <div data-testid="last" style="height:100px; background: #f1fe01">last element on page 2</div>
+
+</body>
+</html>

--- a/test/end2end/1009_spetial_cases_/case_p_comment.html
+++ b/test/end2end/1009_spetial_cases_/case_p_comment.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="">
+<head>
+  <meta charset="utf-8">
+  <title>case_chain_equal_bottom</title>
+  <link rel="stylesheet" href="../../shared/css/main.css">
+
+  <script defer
+          data-debug-mode="true"
+          data-markup-debug-mode="true"
+          data-console-assert="true"
+          data-print-height='300px'
+          data-print-width='600px'
+          data-print-left-margin= '50px'
+          data-print-right-margin= '50px'
+          data-print-top-margin= '50px'
+          data-print-bottom-margin= '50px'
+          data-print-font-size='16px'
+          data-page-break-before-selectors="H1"
+          src="../../../dist/bundle.js"></script>
+</head>
+<body>
+  <!-- 1st page -->
+  <div data-testid="first" style="height:200px; background: #e3e6b3"">full page</div>
+  <!-- 2nd page -->
+  <p data-testid="p"><!-- comment --></p>
+  <h1 data-testid="h1">Header</h1>
+  <div data-testid="last" style="height:100px; background: #f1fe01">last element on page 2</div>
+
+</body>
+</html>

--- a/test/end2end/1009_spetial_cases_/case_p_empty.html
+++ b/test/end2end/1009_spetial_cases_/case_p_empty.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="">
+<head>
+  <meta charset="utf-8">
+  <title>case_chain_equal_bottom</title>
+  <link rel="stylesheet" href="../../shared/css/main.css">
+
+  <script defer
+          data-debug-mode="true"
+          data-markup-debug-mode="true"
+          data-console-assert="true"
+          data-print-height='300px'
+          data-print-width='600px'
+          data-print-left-margin= '50px'
+          data-print-right-margin= '50px'
+          data-print-top-margin= '50px'
+          data-print-bottom-margin= '50px'
+          data-print-font-size='16px'
+          data-page-break-before-selectors="H1"
+          src="../../../dist/bundle.js"></script>
+</head>
+<body>
+  <!-- 1st page -->
+  <div data-testid="first" style="height:200px; background: #e3e6b3"">full page</div>
+  <!-- 2nd page -->
+  <p data-testid="p"></p>
+  <h1 data-testid="h1">Header</h1>
+  <div data-testid="last" style="height:100px; background: #f1fe01">last element on page 2</div>
+
+</body>
+</html>

--- a/test/end2end/1009_spetial_cases_/case_p_node.html
+++ b/test/end2end/1009_spetial_cases_/case_p_node.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="">
+<head>
+  <meta charset="utf-8">
+  <title>case_chain_equal_bottom</title>
+  <link rel="stylesheet" href="../../shared/css/main.css">
+
+  <script defer
+          data-debug-mode="true"
+          data-markup-debug-mode="true"
+          data-console-assert="true"
+          data-print-height='300px'
+          data-print-width='600px'
+          data-print-left-margin= '50px'
+          data-print-right-margin= '50px'
+          data-print-top-margin= '50px'
+          data-print-bottom-margin= '50px'
+          data-print-font-size='16px'
+          data-page-break-before-selectors="H1"
+          src="../../../dist/bundle.js"></script>
+</head>
+<body>
+  <!-- 1st page -->
+  <div data-testid="first" style="height:200px; background: #e3e6b3"">full page</div>
+  <!-- 2nd page -->
+  <p data-testid="p">Text <b>Node</b></p>
+  <h1 data-testid="h1">Header</h1>
+  <div data-testid="last" style="height:100px; background: #f1fe01">last element on page 2</div>
+
+</body>
+</html>

--- a/test/end2end/1009_spetial_cases_/case_p_text.html
+++ b/test/end2end/1009_spetial_cases_/case_p_text.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="">
+<head>
+  <meta charset="utf-8">
+  <title>case_chain_equal_bottom</title>
+  <link rel="stylesheet" href="../../shared/css/main.css">
+
+  <script defer
+          data-debug-mode="true"
+          data-markup-debug-mode="true"
+          data-console-assert="true"
+          data-print-height='300px'
+          data-print-width='600px'
+          data-print-left-margin= '50px'
+          data-print-right-margin= '50px'
+          data-print-top-margin= '50px'
+          data-print-bottom-margin= '50px'
+          data-print-font-size='16px'
+          data-page-break-before-selectors="H1"
+          src="../../../dist/bundle.js"></script>
+</head>
+<body>
+  <!-- 1st page -->
+  <div data-testid="first" style="height:200px; background: #e3e6b3"">full page</div>
+  <!-- 2nd page -->
+  <p data-testid="p">?</p>
+  <h1 data-testid="h1">Header</h1>
+  <div data-testid="last" style="height:100px; background: #f1fe01">last element on page 2</div>
+
+</body>
+</html>

--- a/test/end2end/1009_spetial_cases_/case_p_whitespaces.html
+++ b/test/end2end/1009_spetial_cases_/case_p_whitespaces.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="">
+<head>
+  <meta charset="utf-8">
+  <title>case_chain_equal_bottom</title>
+  <link rel="stylesheet" href="../../shared/css/main.css">
+
+  <script defer
+          data-debug-mode="true"
+          data-markup-debug-mode="true"
+          data-console-assert="true"
+          data-print-height='300px'
+          data-print-width='600px'
+          data-print-left-margin= '50px'
+          data-print-right-margin= '50px'
+          data-print-top-margin= '50px'
+          data-print-bottom-margin= '50px'
+          data-print-font-size='16px'
+          data-page-break-before-selectors="H1"
+          src="../../../dist/bundle.js"></script>
+</head>
+<body>
+  <!-- 1st page -->
+  <div data-testid="first" style="height:200px; background: #e3e6b3"">full page</div>
+  <!-- 2nd page -->
+  <p data-testid="p">                 </p>
+  <h1 data-testid="h1">Header</h1>
+  <div data-testid="last" style="height:100px; background: #f1fe01">last element on page 2</div>
+
+</body>
+</html>

--- a/test/end2end/1009_spetial_cases_/test_case.py
+++ b/test/end2end/1009_spetial_cases_/test_case.py
@@ -1,0 +1,58 @@
+import os
+
+from seleniumbase import BaseCase
+
+from test.end2end.helpers.helper import Helper
+
+path_to_this_test_file_folder = os.path.dirname(os.path.abspath(__file__))
+
+first = '//*[@data-testid="first"]';
+p = '//*[@data-testid="p"]';
+h1 = '//*[@data-testid="h1"]';
+last = '//*[@data-testid="last"]';
+
+class Test(BaseCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = Helper(self)
+
+    @staticmethod
+    def check_empty_P(helper):
+        helper.assert_html2pdf4doc_success()
+        helper.assert_document_has_pages(2)
+        helper.assert_element_ends_page(p, 1)
+        # print-forced-page-break starts the 3rd page
+        helper.assert_element_on_the_page(h1, 2)
+
+    @staticmethod
+    def check_normal_P(helper):
+        helper.assert_html2pdf4doc_success()
+        helper.assert_document_has_pages(3)
+        helper.assert_element_starts_page(p, 2)
+        # print-forced-page-break starts the 3rd page
+        helper.assert_element_on_the_page(h1, 3)
+
+    # base behavior
+    def test_p_empty(self):
+        self.helper.open_case(path_to_this_test_file_folder, 'p_empty')
+        self.check_empty_P(self.helper)
+
+    def test_p_whitespaces(self):
+        self.helper.open_case(path_to_this_test_file_folder, 'p_whitespaces')
+        self.check_empty_P(self.helper)
+
+    def test_p_comment(self):
+        self.helper.open_case(path_to_this_test_file_folder, 'p_comment')
+        self.check_empty_P(self.helper)
+
+    def test_p_node(self):
+        self.helper.open_case(path_to_this_test_file_folder, 'p_node')
+        self.check_normal_P(self.helper)
+
+    def test_p_text(self):
+        self.helper.open_case(path_to_this_test_file_folder, 'p_text')
+        self.check_normal_P(self.helper)
+
+    def test_p_br(self):
+        self.helper.open_case(path_to_this_test_file_folder, 'p_br')
+        self.check_normal_P(self.helper)


### PR DESCRIPTION
This PR combines the empty-spacer paragraph fix with a minimal deferred mutation pipeline.

**Problem:**
User-generated HTML may contain empty spacer <p> nodes. When such a paragraph becomes a page-start candidate near forced breaks, pagination can produce an unjustified blank page.

**Solution:**

1. Empty spacer paragraph handling:
- Added a dedicated structural predicate for ignorable spacer paragraphs.
- During page-start registration, such paragraphs are skipped as page-start candidates.
2. Deferred mutation pipeline:
- Added a lightweight mutation queue.
- Added mutation commands, including hide-ignorable-spacer-paragraph.
- Pages now registers the spacer hide as a deferred mutation instead of mutating DOM immediately.
- Preview flushes deferred mutations at create-time.

**Result:**
- The empty spacer `<p>` case is handled safely.
- DOM writes for this case are now deferred to the Preview stage, reducing immediate layout-impacting mutations during pagination calculations.